### PR TITLE
Add badges

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -16,9 +16,9 @@ env:
   # Maximum cache period (in weeks) before forcing a new cache upload.
   CACHE_PERIOD: "2"
   # Increment the build number to force new mambaforge cache upload.
-  MAMBA_CACHE_BUILD: "1"
+  MAMBA_CACHE_BUILD: "0"
   # Increment the build number to force new mint cache upload.
-  MINT_CACHE_BUILD: "1"
+  MINT_CACHE_BUILD: "0"
   # Base environment conda packages to be installed
   MAMBA_CACHE_PACKAGES: "pip conda-lock"
 
@@ -56,17 +56,17 @@ linux_task:
     - conda info --all
     - conda list --name base
   mint_cache:
-    folder: ${CIRRUS_WORKING_DIR}/requirements
+    folder: ${CIRRUS_WORKING_DIR}/mambaforge/envs/py${PY_VER}
     fingerprint_script:
-      - echo "${CIRRUS_OS} tests for Python v${PY_VER}"
+      - echo "${CIRRUS_OS} py${PY_VER} tests"
       - echo "$(date +%Y).$(expr $(date +%U) / ${CACHE_PERIOD}):${MINT_CACHE_BUILD}"
       - cat ${CIRRUS_WORKING_DIR}/requirements/py$(echo ${PY_VER} | tr -d ".").yml
     populate_script:
       - conda-lock --mamba --platform linux-64 --file ${CIRRUS_WORKING_DIR}/requirements/py$(echo ${PY_VER} | tr -d ".").yml
       - mamba create --name py${PY_VER} --quiet --file conda-linux-64.lock
+      - conda info --envs
   test_script:
     - source activate py${PY_VER}
-    - conda info --envs
     - pip install --no-deps --editable .
     - pytest
 
@@ -89,7 +89,7 @@ osx_task:
       - wget --quiet https://github.com/conda-forge/miniforge/releases/latest/download/Mambaforge-MacOSX-x86_64.sh -O mambaforge.sh
       - echo "${CIRRUS_OS} $(shasum -a 256 mambaforge.sh)"
       - echo "${MAMBA_CACHE_PACKAGES}"
-      - echo "$(date +%Y).$(expr $(date +%U) / ${CACHE_PERIOD}):${CONDA_CACHE_BUILD}"
+      - echo "$(date +%Y).$(expr $(date +%U) / ${CACHE_PERIOD}):${MAMBA_CACHE_BUILD}"
     populate_script:
       - bash mambaforge.sh -b -p ${HOME}/mambaforge
       - conda config --set always_yes yes --set changeps1 no
@@ -100,16 +100,16 @@ osx_task:
     - conda info --all
     - conda list --name base
   mint_cache:
-    folder: ${CIRRUS_WORKING_DIR}/requirements
+    folder: ${CIRRUS_WORKING_DIR}/mambaforge/envs/py${PY_VER}
     fingerprint_script:
-      - echo "${CIRRUS_OS} tests for Python ${PY_VER}"
+      - echo "${CIRRUS_OS} py${PY_VER} tests"
       - echo "$(date +%Y).$(expr $(date +%U) / ${CACHE_PERIOD}):${MINT_CACHE_BUILD}"
       - cat ${CIRRUS_WORKING_DIR}/requirements/py$(echo ${PY_VER} | tr -d ".").yml
     populate_script:
       - conda-lock --mamba --platform osx-64 --file ${CIRRUS_WORKING_DIR}/requirements/py$(echo ${PY_VER} | tr -d ".").yml
       - mamba create --name py${PY_VER} --quiet --file conda-osx-64.lock
+      - conda info --envs
   test_script:
     - source activate py${PY_VER}
-    - conda info --envs
     - pip install --no-deps --editable .
     - pytest

--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ pip-cache
 \.\#*
 *.swp
 .ipynb_checkpoints
+.idea
 
 # MINT files
 mint/__init__.py

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MINT - Mimetic INTerpolation on the Sphere
 
-<p align="center">
+<p align="left">
 <a href="https://cirrus-ci.com/github/pletzer/mint">
 <img src="https://api.cirrus-ci.com/github/pletzer/mint.svg?branch=master"
      alt="Cirrus-CI" /></a>

--- a/README.md
+++ b/README.md
@@ -1,4 +1,21 @@
-MINT - Mimetic INTerpolation on the Sphere
+# MINT - Mimetic INTerpolation on the Sphere
+
+<p align="center">
+<a href="https://cirrus-ci.com/github/pletzer/mint">
+<img src="https://api.cirrus-ci.com/github/pletzer/mint.svg?branch=master"
+     alt="Cirrus-CI" /></a>
+<a href="https://github.com/pletzer/mint/graphs/contributors">
+<img src="https://img.shields.io/github/contributors/pletzer/mint.svg"
+     alt="# contributors" /></a>
+<a href="https://github.com/pletzer/mint/releases">
+<img src="https://img.shields.io/github/v/release/pletzer/mint"
+     alt="latest release" /></a>
+<a href="https://github.com/pletzer/mint/commits/master">
+<img src="https://img.shields.io/github/commits-since/pletzer/mint/latest.svg"
+     alt="Commits since last release" /></a>
+</p>
+
+----
 
 ## Overview
 
@@ -11,7 +28,7 @@ loop integrals of an interpolated vector field deriving from a gradient is zero.
 
 ## Prerequisites
 
-To build the MINT Python module:
+To build the `MINT` Python module:
 
  * C++ compiler with C++11 support
  * Cython
@@ -19,9 +36,9 @@ To build the MINT Python module:
  * NumPy
  * VTK
 
-We recommend to install the above packages with conda.
+We recommend installing the above packages using `conda`.
 
-To build the MINT C++ library and the tools:
+To build the `MINT` C++ library and the tools:
 
  * C++ compiler with C++11 support
  * Fortran compiler (e.g., gfortran 6.4)
@@ -29,16 +46,16 @@ To build the MINT C++ library and the tools:
  * Doxygen
  * VTK
 
-## How to build the MINT Python module
+## How to Build the MINT Python Module
 
-The MINT Python interface requires VTK, netCDF and the tbb libraries to 
+The `MINT` Python interface requires `VTK`, `netCDF` and the `tbb` libraries to 
 be installed. This is most easily done in a conda environment:
 ```
 conda env create --file requirements/mint.yml
 conda activate mint-dev
 ```
 
-In the root MINT directory then type:
+In the root `MINT` directory then type:
 ```
 pip install --no-deps --editable .
 ```
@@ -53,8 +70,9 @@ To run the tests type:
 pytest
 ```
  
-## How to build the MINT C++ library so you can call it from your program (Fortran or C/C++)
+## How to Build the MINT C++ Library
 
+Perform the following in order to call `MINT` from `Fortran`, `C` or `C++`:
 ```
 mkdir build
 cd build
@@ -62,19 +80,20 @@ cmake ..
 make -j 8
 ```
 
-You can specify the compiler with
+You can specify the compiler with:
 ```
 FC=mpif90 CXX=mpicxx cmake ..; make -j 8
 ```
 
-You can check that the build was successful by typing
+You can check that the build was successful by typing:
 ```
 make test
 ```
 
-### Binary tools
+### Binary Tools
 
-The above CMake build will compile a number of tools. To run the tools, set MINT_SRC_DIR to the location of the MINT source directory (e.g. `export MINT_SRC_DIR=..`).
+The above `CMake` build will compile a number of tools. To run the tools, set
+`MINT_SRC_DIR` to the location of the `MINT` source directory (e.g. `export MINT_SRC_DIR=..`).
 
  1. Compute the interpolation weights from a lat-lon grid to the cubed sphere:
  ```
@@ -83,7 +102,7 @@ The above CMake build will compile a number of tools. To run the tools, set MINT
                       -w weights.nc
  ```
 
- 2. Regrid field "edge_integrated_velocity" from lat-lon to cubed-sphere by loading the previously generated weights:
+ 2. Regrid field `edge_integrated_velocity` from lat-lon to cubed-sphere by loading the previously generated weights:
  ```
  ./tools/regrid_edges -s $MINT_SRC_DIR/data/latlon4x2.nc:latlon -S 0 \
                       -d $MINT_SRC_DIR/data/cs_4.nc:physics -D 1 \
@@ -109,12 +128,12 @@ The above CMake build will compile a number of tools. To run the tools, set MINT
 
 ## API Documentation
 
-This is useful if you would like to call MINT from C, Python or Fortran:
+This is useful if you would like to call `MINT` from `C`, `Python` or `Fortran`:
 
 https://pletzer.github.io/mint/html/
 
 
-## Conservation error
+## Conservation Error
 
 The plot below shows the error of mimetic regridding error obtained by computing the 
 closed line integral for each cell. 


### PR DESCRIPTION
This PR adds various badges to the `README.md`

It also addresses an oversight in the `.cirrus.yml` where I failed to cache the appropriate conda environment for each task.

See [here](https://cirrus-ci.com/build/4978864536420352) for the associated `cirrus-ci` job run for the commit of this PR.

Also, see [here](https://github.com/bjlittle/mint/tree/add-badges#mint---mimetic-interpolation-on-the-sphere) for how the new `README.md` renders with the badges. Note that, the build status of `cirrus-ci` for `mint` is `unknown` as there hasn't been a PR on the repo with `cirrus-ci` enabled.

@pletzer See below on instructions for how-to register `mint` for the `cirrus-ci` service.