### PR TITLE
fix cirrus-ci for bad linux kernel version

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -46,7 +46,9 @@ linux_task:
       - echo "${CIRRUS_OS} $(sha256sum mambaforge.sh)"
       - echo "${MAMBA_CACHE_PACKAGES}"
       - echo "$(date +%Y).$(expr $(date +%U) / ${CACHE_PERIOD}):${MAMBA_CACHE_BUILD}"
+      - uname -r
     populate_script:
+      - export CONDA_OVERRIDE_LINUX="$(uname -r | cut -d'+' -f1)"
       - bash mambaforge.sh -b -p ${HOME}/mambaforge
       - conda config --set always_yes yes --set changeps1 no
       - conda config --set show_channel_urls True
@@ -61,7 +63,9 @@ linux_task:
       - echo "${CIRRUS_OS} py${PY_VER} tests"
       - echo "$(date +%Y).$(expr $(date +%U) / ${CACHE_PERIOD}):${MINT_CACHE_BUILD}"
       - cat ${CIRRUS_WORKING_DIR}/requirements/py$(echo ${PY_VER} | tr -d ".").yml
+      - uname -r
     populate_script:
+      - export CONDA_OVERRIDE_LINUX="$(uname -r | cut -d'+' -f1)"
       - conda-lock --mamba --platform linux-64 --file ${CIRRUS_WORKING_DIR}/requirements/py$(echo ${PY_VER} | tr -d ".").yml
       - mamba create --name py${PY_VER} --quiet --file conda-linux-64.lock
       - conda info --envs


### PR DESCRIPTION
@pletzer This PR addresses an issue resulting from the recent release of `conda` 4.10.0.

The new release of `conda` fails to deal with the (poorly) named new Linux Kernel version `5.4.89+` - causing `conda` to fail to `update` or `create` new environments i.e., the trailing `+` symbol is the troublesome culprit here.

Cirrus-CI has recently migrated its Linux kernel infrastructure to `5.4.89+`. 

This PR works around the problem via the `CONDA_OVERRIDE_LINUX` environment variable.

Reference: 
- https://github.com/conda/conda/issues/10596
- https://github.com/cirruslabs/cirrus-ci-docs/issues/837