### PR TITLE
revert cirrus-ci gcc + fixes

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -36,7 +36,7 @@ linux_task:
       PY_VER: "3.8"
   name: "Linux: py${PY_VER}"
   container:
-    image: gcc:latest
+    dockerfile: requirements/ci/linux/Dockerfile
   env:
     PATH: ${HOME}/mambaforge/bin:${PATH}
   mamba_cache:
@@ -46,9 +46,7 @@ linux_task:
       - echo "${CIRRUS_OS} $(sha256sum mambaforge.sh)"
       - echo "${MAMBA_CACHE_PACKAGES}"
       - echo "$(date +%Y).$(expr $(date +%U) / ${CACHE_PERIOD}):${MAMBA_CACHE_BUILD}"
-      - uname -r
     populate_script:
-      - export CONDA_OVERRIDE_LINUX="$(uname -r | cut -d'+' -f1)"
       - bash mambaforge.sh -b -p ${HOME}/mambaforge
       - conda config --set always_yes yes --set changeps1 no
       - conda config --set show_channel_urls True
@@ -58,19 +56,19 @@ linux_task:
     - conda info --all
     - conda list --name base
   mint_cache:
-    folder: ${CIRRUS_WORKING_DIR}/mambaforge/envs/py${PY_VER}
+    folder: ${HOME}/mambaforge/envs/py${PY_VER}
     fingerprint_script:
       - echo "${CIRRUS_OS} py${PY_VER} tests"
       - echo "$(date +%Y).$(expr $(date +%U) / ${CACHE_PERIOD}):${MINT_CACHE_BUILD}"
       - cat ${CIRRUS_WORKING_DIR}/requirements/py$(echo ${PY_VER} | tr -d ".").yml
-      - uname -r
     populate_script:
-      - export CONDA_OVERRIDE_LINUX="$(uname -r | cut -d'+' -f1)"
       - conda-lock --mamba --platform linux-64 --file ${CIRRUS_WORKING_DIR}/requirements/py$(echo ${PY_VER} | tr -d ".").yml
       - mamba create --name py${PY_VER} --quiet --file conda-linux-64.lock
-      - conda info --envs
+      - cp conda-linux-64.lock ${HOME}/mambaforge/envs/py${PY_VER}
   test_script:
-    - source activate py${PY_VER}
+    - cat ${HOME}/mambaforge/envs/py${PY_VER}/conda-linux-64.lock >&2
+    - source ${HOME}/mambaforge/etc/profile.d/conda.sh >/dev/null 2>&1
+    - conda activate py${PY_VER} >/dev/null 2>&1
     - pip install --no-deps --editable .
     - pytest
 
@@ -104,16 +102,20 @@ osx_task:
     - conda info --all
     - conda list --name base
   mint_cache:
-    folder: ${CIRRUS_WORKING_DIR}/mambaforge/envs/py${PY_VER}
+    folder: ${HOME}/mambaforge/envs/py${PY_VER}
     fingerprint_script:
       - echo "${CIRRUS_OS} py${PY_VER} tests"
       - echo "$(date +%Y).$(expr $(date +%U) / ${CACHE_PERIOD}):${MINT_CACHE_BUILD}"
       - cat ${CIRRUS_WORKING_DIR}/requirements/py$(echo ${PY_VER} | tr -d ".").yml
     populate_script:
       - conda-lock --mamba --platform osx-64 --file ${CIRRUS_WORKING_DIR}/requirements/py$(echo ${PY_VER} | tr -d ".").yml
-      - mamba create --name py${PY_VER} --quiet --file conda-osx-64.lock
-      - conda info --envs
+      - mamba create --yes --name py${PY_VER} --quiet --file conda-osx-64.lock
+      - cp conda-osx-64.lock ${HOME}/mambaforge/envs/py${PY_VER}
+  mesa_script:
+    - brew install mesa
   test_script:
-    - source activate py${PY_VER}
+    - cat ${HOME}/mambaforge/envs/py${PY_VER}/conda-osx-64.lock >&2
+    - source ${HOME}/mambaforge/etc/profile.d/conda.sh >/dev/null 2>&1
+    - conda activate py${PY_VER} >/dev/null 2>&1
     - pip install --no-deps --editable .
     - pytest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ requires = [
     "setuptools>=40.8.0",
     "wheel",
     "netCDF4",
-    "vtk==9.0.1",
+    "vtk==8.2.0",
 ]
 # Defined by PEP 517
 build-backend = "setuptools.build_meta"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ requires = [
     "setuptools>=40.8.0",
     "wheel",
     "netCDF4",
-    "vtk==8.2.0",
+    "vtk==8.1.2",
 ]
 # Defined by PEP 517
 build-backend = "setuptools.build_meta"

--- a/requirements/ci/linux/Dockerfile
+++ b/requirements/ci/linux/Dockerfile
@@ -1,0 +1,12 @@
+FROM gcc:10 
+
+LABEL author="bjlittle" \
+      version="0.1" \
+      description="MINT docker image with gcc and mesa"
+
+#
+# install system-level dependencies
+#
+RUN apt update -y \
+  && apt upgrade -y \
+  && apt install -y libgl1-mesa-dev 

--- a/requirements/py36.yml
+++ b/requirements/py36.yml
@@ -17,7 +17,7 @@ dependencies:
 # Core dependencies.
   - libnetcdf
   - numpy
-  - vtk=8.2.0
+  - vtk=8.1.2
 
 # Test dependencies.
   - pytest

--- a/requirements/py36.yml
+++ b/requirements/py36.yml
@@ -17,7 +17,7 @@ dependencies:
 # Core dependencies.
   - libnetcdf
   - numpy
-  - vtk=9.0.1
+  - vtk=8.2.0
 
 # Test dependencies.
   - pytest

--- a/requirements/py36.yml
+++ b/requirements/py36.yml
@@ -17,7 +17,7 @@ dependencies:
 # Core dependencies.
   - libnetcdf
   - numpy
-  - vtk=8.2.0
+  - vtk=9.0.1
 
 # Test dependencies.
   - pytest

--- a/requirements/py37.yml
+++ b/requirements/py37.yml
@@ -17,7 +17,7 @@ dependencies:
 # Core dependencies.
   - libnetcdf
   - numpy
-  - vtk=8.2.0
+  - vtk=8.1.2
 
 # Test dependencies.
   - pytest

--- a/requirements/py37.yml
+++ b/requirements/py37.yml
@@ -17,7 +17,7 @@ dependencies:
 # Core dependencies.
   - libnetcdf
   - numpy
-  - vtk=9.0.1
+  - vtk=8.2.0
 
 # Test dependencies.
   - pytest

--- a/requirements/py37.yml
+++ b/requirements/py37.yml
@@ -17,7 +17,7 @@ dependencies:
 # Core dependencies.
   - libnetcdf
   - numpy
-  - vtk=8.2.0
+  - vtk=9.0.1
 
 # Test dependencies.
   - pytest

--- a/requirements/py38.yml
+++ b/requirements/py38.yml
@@ -17,7 +17,7 @@ dependencies:
 # Core dependencies.
   - libnetcdf
   - numpy
-  - vtk=8.2.0
+  - vtk=8.1.2
 
 # Test dependencies.
   - pytest

--- a/requirements/py38.yml
+++ b/requirements/py38.yml
@@ -17,7 +17,7 @@ dependencies:
 # Core dependencies.
   - libnetcdf
   - numpy
-  - vtk=9.0.1
+  - vtk=8.2.0
 
 # Test dependencies.
   - pytest

--- a/requirements/py38.yml
+++ b/requirements/py38.yml
@@ -17,7 +17,7 @@ dependencies:
 # Core dependencies.
   - libnetcdf
   - numpy
-  - vtk=8.2.0
+  - vtk=9.0.1
 
 # Test dependencies.
   - pytest

--- a/setup.cfg
+++ b/setup.cfg
@@ -43,7 +43,7 @@ install_requires =
     netCDF4
     numpy
     tbb
-    vtk == 9.0.1
+    vtk == 8.2.0
 package_dir =
     mint=mint
 packages = find:
@@ -53,7 +53,7 @@ setup_requires =
     setuptools >= 40.8.0
     wheel
     netCDF4
-    vtk == 9.0.1
+    vtk == 8.2.0
 tests_require =
     pytest
 zip_safe = False

--- a/setup.cfg
+++ b/setup.cfg
@@ -43,7 +43,7 @@ install_requires =
     netCDF4
     numpy
     tbb
-    vtk == 8.2.0
+    vtk == 8.1.2
 package_dir =
     mint=mint
 packages = find:
@@ -53,7 +53,7 @@ setup_requires =
     setuptools >= 40.8.0
     wheel
     netCDF4
-    vtk == 8.2.0
+    vtk == 8.1.2
 tests_require =
     pytest
 zip_safe = False


### PR DESCRIPTION
This PR pins `gcc` back to `10.x` to allow `mint` to successfully build and install on `cirrus-ci`.

The PR also installs `mesa` for both `linux` and `osx`, which is now a platform level dependency given the changed use of `vtk` by `mint`.

On `linux`, we instruct `cirrus-ci` to create a custom `docker` image based on `gcc:10` and use `apt` to install `libgl1-mesa-dev`.

On `osx`, we use the natively installed `brew`, which is part of the `catalina-xcode` image, to install `mesa` and its system level dependencies.