### PR TITLE
Prevent running tests from creating files not ignored in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,7 +21,10 @@ pip-cache
 .coverage
 .pytest_cache
 
-# Created by editiors
+# Build
+cmake-build-debug/
+
+# Created by editors
 *~
 \#*
 \.\#*

--- a/mint/tests/test_grid.py
+++ b/mint/tests/test_grid.py
@@ -1,9 +1,8 @@
 from mint import Grid
 import numpy
-import sys
 from pathlib import Path
 import vtk
-
+from tempfile import NamedTemporaryFile
 
 def test_create_grid():
     # create the grid
@@ -18,7 +17,8 @@ def test_create_grid():
                           (2., 1., 0.),
                           (1., 1., 0.)]).reshape(2, 4, 3)
     gr.setPoints(points)
-    gr.dump('test_create_grid.vtk')
+    with NamedTemporaryFile() as f:
+        gr.dump(f.name)
 
 def test_attach_data():
     # create the grid
@@ -37,15 +37,16 @@ def test_attach_data():
     nDataPerCell = 3
     data = numpy.arange(0, 2*nDataPerCell, dtype=numpy.float64).reshape((2, nDataPerCell))
     gr.attach('mydata', data)
-    gr.dump('test_create_grid_with_data.vtk')
-    # read the data back to check the layout of the data
-    reader = vtk.vtkUnstructuredGridReader()
-    reader.SetFileName('test_create_grid_with_data.vtk')
-    reader.Update()
-    ugrid = reader.GetOutput()
-    arr = ugrid.GetCellData().GetArray('mydata')
-    assert(arr.GetNumberOfTuples() == gr.getNumberOfCells())
-    assert(arr.GetNumberOfComponents() == nDataPerCell)
+    with NamedTemporaryFile() as f:
+        gr.dump(f.name)
+        # read the data back to check the layout of the data
+        reader = vtk.vtkUnstructuredGridReader()
+        reader.SetFileName(f.name)
+        reader.Update()
+        ugrid = reader.GetOutput()
+        arr = ugrid.GetCellData().GetArray('mydata')
+        assert(arr.GetNumberOfTuples() == gr.getNumberOfCells())
+        assert(arr.GetNumberOfComponents() == nDataPerCell)
 
 def test_load_grid():
     gr = Grid()

--- a/mint/tests/test_vector_interp.py
+++ b/mint/tests/test_vector_interp.py
@@ -2,6 +2,8 @@ from mint import Grid
 from mint import VectorInterp
 import numpy
 import vtk
+from tempfile import TemporaryDirectory
+from os import sep
 
 
 def generateStructuredGridPoints(nx, ny, v0, v1, v2, v3):
@@ -171,27 +173,28 @@ def test_slanted():
     # all points fall within the source grid so numBad == 0
     assert(numBad == 0)
 
-    # generate edge data
-    data = numpy.zeros((numCells, 4), numpy.float64)
-    for cellId in range(numCells):
-        # iterate over the edges of the source grid cells
-        for edgeIndex in range(4):
+    with TemporaryDirectory() as d:
+        # generate edge data
+        data = numpy.zeros((numCells, 4), numpy.float64)
+        for cellId in range(numCells):
+            # iterate over the edges of the source grid cells
+            for edgeIndex in range(4):
 
-            # set one edge to 1, all other edges to zero
-            data[cellId, edgeIndex] = 1.0
+                # set one edge to 1, all other edges to zero
+                data[cellId, edgeIndex] = 1.0
 
-            # get the edge interpolated vectors
-            vectorData = vi.getEdgeVectors(data)
-            fileName = f'slanted_edgeVectors_cellId{cellId}edgeIndex{edgeIndex}.vtk'
-            saveVectorsVTKFile(targetPoints, vectorData, fileName)
+                # get the edge interpolated vectors
+                vectorData = vi.getEdgeVectors(data)
+                fileName = f'{d}{sep}slanted_edgeVectors_cellId{cellId}edgeIndex{edgeIndex}.vtk'
+                saveVectorsVTKFile(targetPoints, vectorData, fileName)
 
-            # get the lateral face interpolated vectors
-            vectorData = vi.getFaceVectors(data)
-            fileName = f'slanted_faceVectors_cellId{cellId}edgeIndex{edgeIndex}.vtk'
-            saveVectorsVTKFile(targetPoints, vectorData, fileName)
+                # get the lateral face interpolated vectors
+                vectorData = vi.getFaceVectors(data)
+                fileName = f'{d}{sep}slanted_faceVectors_cellId{cellId}edgeIndex{edgeIndex}.vtk'
+                saveVectorsVTKFile(targetPoints, vectorData, fileName)
 
-            # reset this edge's value back to its original
-            data[cellId, edgeIndex] = 0.0
+                # reset this edge's value back to its original
+                data[cellId, edgeIndex] = 0.0
 
 
 def test_degenerate():
@@ -222,26 +225,27 @@ def test_degenerate():
     # all points fall within the source grid so numBad == 0
     assert(numBad == 0)
 
-    # generate edge data
-    data = numpy.zeros((numCells, 4), numpy.float64)
-    for cellId in range(numCells):
-        # iterate over the edges of the source grid cells
-        for edgeIndex in range(4):
+    with TemporaryDirectory() as d:
+        # generate edge data
+        data = numpy.zeros((numCells, 4), numpy.float64)
+        for cellId in range(numCells):
+            # iterate over the edges of the source grid cells
+            for edgeIndex in range(4):
 
-            # set one edge to 1, all other edges to zero
-            data[cellId, edgeIndex] = 1.0
+                # set one edge to 1, all other edges to zero
+                data[cellId, edgeIndex] = 1.0
 
-            # get the edge interpolated vectors
-            vectorData = vi.getEdgeVectors(data)
+                # get the edge interpolated vectors
+                vectorData = vi.getEdgeVectors(data)
 
-            # get the face interpolated vectors
-            vectorData = vi.getFaceVectors(data)
+                # get the face interpolated vectors
+                vectorData = vi.getFaceVectors(data)
 
-            # reset this edge's value back to its original
-            data[cellId, edgeIndex] = 0.0
+                # reset this edge's value back to its original
+                data[cellId, edgeIndex] = 0.0
 
-            fileName = f'degenerate_cellId{cellId}edgeIndex{edgeIndex}.vtk'
-            saveVectorsVTKFile(targetPoints, vectorData, fileName)
+                fileName = f'{d}{sep}degenerate_cellId{cellId}edgeIndex{edgeIndex}.vtk'
+                saveVectorsVTKFile(targetPoints, vectorData, fileName)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Hi,

Noticed this last time I ran the tests in the project. While the tests are super fast to run (Kudos! Was expecting the tests to take much longer) it creates a few new files that are not ignored in git. And ignoring by extension wouldn't work since there are other files with the same extension in the project.

```bash
(mint-dev) (venv) kinow@ranma:~/Development/python/workspace/mint$ git status
On branch gitignore
Untracked files:
  (use "git add <file>..." to include in what will be committed)
	degenerate_cellId0edgeIndex0.vtk
	degenerate_cellId0edgeIndex1.vtk
	degenerate_cellId0edgeIndex2.vtk
	degenerate_cellId0edgeIndex3.vtk
	slanted_edgeVectors_cellId0edgeIndex0.vtk
	slanted_edgeVectors_cellId0edgeIndex1.vtk
	slanted_edgeVectors_cellId0edgeIndex2.vtk
	slanted_edgeVectors_cellId0edgeIndex3.vtk
	slanted_faceVectors_cellId0edgeIndex0.vtk
	slanted_faceVectors_cellId0edgeIndex1.vtk
	slanted_faceVectors_cellId0edgeIndex2.vtk
	slanted_faceVectors_cellId0edgeIndex3.vtk
	test_create_grid_with_data.vtk

nothing added to commit but untracked files present (use "git add" to track)
```

Also, when building with an IDE (CLion, but could be true for Eclipse + CDT or Visual Studio?) it created a CMake directory that was also not ignored. So I've included that one too since it appeared to be harmless? But since I haven't used CMake in a long time, let me know if I should update or remove that change :+1: 

```bash
(mint-dev) (venv) kinow@ranma:~/Development/python/workspace/mint$ git status
On branch gitignore
Untracked files:
  (use "git add <file>..." to include in what will be committed)
	cmake-build-debug/

nothing added to commit but untracked files present (use "git add" to track)
```

Thanks!
Bruno