### PR TITLE
Core build of MINT

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -70,12 +70,13 @@ linux_task:
     - cat ${HOME}/mambaforge/envs/py${PY_VER}/conda-linux-64.lock >&2
     - source ${HOME}/mambaforge/etc/profile.d/conda.sh >/dev/null 2>&1
     - conda activate py${PY_VER} >/dev/null 2>&1
+    - conda install --yes -c conda-forge netcdf-fortran doxygen 2>&1
     - conda list
     - pip install --no-deps --editable .
     - pytest
     - mkdir build-cmake
     - cd build-cmake
-    - cmake -DVTK_INCLUDE_DIR=${ENV_DIR}/include/vtk-9.0 -DVTK_LIBRARY_DIR=${ENV_DIR}/lib -DVTK_VERSION=9.0 ..
+    - cmake -DBUILD_FORTRAN=ON -DVTK_INCLUDE_DIR=${ENV_DIR}/include/vtk-9.0 -DVTK_LIBRARY_DIR=${ENV_DIR}/lib ..
     - make
     - ctest
 
@@ -124,12 +125,13 @@ osx_task:
     - cat ${HOME}/mambaforge/envs/py${PY_VER}/conda-osx-64.lock >&2
     - source ${HOME}/mambaforge/etc/profile.d/conda.sh >/dev/null 2>&1
     - conda activate py${PY_VER} >/dev/null 2>&1
+    - conda install --yes -c conda-forge netcdf-fortran doxygen 2>&1
     - pip install --no-deps --editable .
     - pytest
     - mkdir build-cmake
     - cd build-cmake
-    - cmake -DBUILD_FORTRAN=OFF -DVTK_INCLUDE_DIR=${ENV_DIR}/include/vtk-9.0 -DVTK_LIBRARY_DIR=${ENV_DIR}/lib -DVTK_VERSION=9.0 ..
-    - make VERBOSE=1 # link error
+    - cmake -DBUILD_FORTRAN=ON -DVTK_INCLUDE_DIR=${ENV_DIR}/include/vtk-9.0 -DVTK_LIBRARY_DIR=${ENV_DIR}/lib ..
+    - make
     - ctest
 
 #
@@ -167,22 +169,16 @@ win_task:
     # - pytest mint\tests
     # - ps: Get-Command python
     # - echo %PATH%
-    # - dir C:\Users\ContainerAdministrator\miniconda3\Library\bin
-    # - dir C:\Users\ContainerAdministrator\miniconda3\Library\bin\vtkRendering*.dll
-    # - python -c "import vtk"
+    # - dir C:%CONDA_LIB%\bin\vtkRendering*.dll
+    # - python -c "import vtk" fails
   test_script:
     - mkdir build-cmake
     - cd build-cmake
-    - dir "C:\Program Files (x86)\Microsoft Visual Studio\2019\"
-    - dir "C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools"
-    - dir "C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\VC"
-    - dir "C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\VC\Auxiliary\"
-    - dir "C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\VC\Auxiliary\Build\"
-    - dir "C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\VC\Auxiliary\Build\vcvars64.bat"
     - call "C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\VC\Auxiliary\Build\vcvars64.bat"
-    - where cl
-    - dir "%CONDA_LIB%\lib
-    - dir "%CONDA_LIB%\include\vtk-9.0"
-    - cmake -G "NMake Makefiles" -DBUILD_FORTRAN=OFF -DVTK_INCLUDE_DIR="%CONDA_LIB%\include\vtk-9.0" -DVTK_LIBRARY_DIR="%CONDA_LIB%\lib" -DNETCDF_INCLUDE_DIRS="%CONDA_LIB%\include" -DNETCDF_LIBRARIES="%CONDA_LIB%\lib\netcdf.lib" ..
+    # - where cl
+    # - dir "%CONDA_LIB%\lib
+    # - dir "%CONDA_LIB%\include\vtk-9.0"
+    - cmake -G "NMake Makefiles" -DVTK_INCLUDE_DIR="%CONDA_LIB%\include\vtk-9.0" -DVTK_LIBRARY_DIR="%CONDA_LIB%\lib" -DNETCDF_INCLUDE_DIRS="%CONDA_LIB%\include" -DNETCDF_LIBRARIES="%CONDA_LIB%\lib\netcdf.lib" ..
     - nmake
     - ctest
+    - cd ../

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -125,7 +125,6 @@ osx_task:
     - cat ${HOME}/mambaforge/envs/py${PY_VER}/conda-osx-64.lock >&2
     - source ${HOME}/mambaforge/etc/profile.d/conda.sh >/dev/null 2>&1
     - conda activate py${PY_VER} >/dev/null 2>&1
-    - conda install --yes -c conda-forge netcdf-fortran doxygen 2>&1
     - pip install --no-deps --editable .
     - pytest
     - mkdir build-cmake

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -130,7 +130,7 @@ osx_task:
     - pytest
     - mkdir build-cmake
     - cd build-cmake
-    - cmake -DBUILD_FORTRAN=ON -DVTK_INCLUDE_DIR=${ENV_DIR}/include/vtk-9.0 -DVTK_LIBRARY_DIR=${ENV_DIR}/lib ..
+    - cmake -DBUILD_FORTRAN=OFF -DVTK_INCLUDE_DIR=${ENV_DIR}/include/vtk-9.0 -DVTK_LIBRARY_DIR=${ENV_DIR}/lib ..
     - make
     - ctest
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,7 @@ endif()
 set(CMAKE_CXX_STANDARD 11)
 enable_testing()
 
-option(BUILD_FORTRAN "Whether or not to build Fortran code" ON)
+option(BUILD_FORTRAN "Whether or not to build Fortran code" OFF)
 if (BUILD_FORTRAN)
     enable_language(Fortran)
 endif()
@@ -92,12 +92,17 @@ else ()
     endif()
 endif()
 
+
+#
+# Find NetCDF
+#
+
 # allow the user to set the variables manually
 set(NETCDF_INCLUDE_DIRS "" CACHE PATH "Directories containing the netCDF C include files and Fortran module files")
 set(NETCDF_LIBRARIES "" CACHE STRING "List of netCDF libraries")
 
-# Find the NetCDF library. Setting NETCDF_INCLUDE_DIRS and NETCDF_LIBRARIES takes precedence.
-# If not set then key off from nc-config and nf-config
+# Setting NETCDF_INCLUDE_DIRS and NETCDF_LIBRARIES takes precedence.
+# If not set then key off from nc-config and optionally nf-config
 if (NETCDF_INCLUDE_DIRS STREQUAL "" OR NETCDF_LIBRARIES STREQUAL "")
     execute_process(COMMAND "nc-config" "--includedir"
         OUTPUT_VARIABLE C_NETCDF_INCLUDE_DIR)
@@ -112,12 +117,20 @@ if (NETCDF_INCLUDE_DIRS STREQUAL "" OR NETCDF_LIBRARIES STREQUAL "")
             OUTPUT_VARIABLE FORTRAN_NETCDF_INCLUDE_DIR)
         execute_process(COMMAND "nf-config" "--flibs"
             OUTPUT_VARIABLE FORTRAN_NETCDF_LIBRARIES)
-        string(STRIP "${FORTRAN_NETCDF_INCLUDE_DIR}" FORTRAN_NETCDF_INCLUDE_DIR)
-        string(STRIP "${FORTRAN_NETCDF_LIBRARIES}" FORTRAN_NETCDF_LIBRARIES)
+        if (FORTRAN_NETCDF_INCLUDE_DIR STREQUAL "" OR FORTRAN_NETCDF_LIBRARIES STREQUAL "")
+            message(STATUS "Command nf-config was not found")
+            set(BUILD_FORTRAN OFF)
+        else()
+            string(STRIP "${FORTRAN_NETCDF_INCLUDE_DIR}" FORTRAN_NETCDF_INCLUDE_DIR)
+            string(STRIP "${FORTRAN_NETCDF_LIBRARIES}" FORTRAN_NETCDF_LIBRARIES)
+        endif()
     endif()
 
     set(NETCDF_INCLUDE_DIRS ${C_NETCDF_INCLUDE_DIR} ${FORTRAN_NETCDF_INCLUDE_DIR})
     set(NETCDF_LIBRARIES ${C_NETCDF_LIBRARIES} ${FORTRAN_NETCDF_LIBRARIES})
+    if (NOT BUILD_FORTRAN)
+        message(STATUS "Will not build Fortran interface")
+    endif()
 endif()
 
 if ("${NETCDF_INCLUDE_DIRS}" STREQUAL "" OR "${NETCDF_LIBRARIES}" STREQUAL "")
@@ -125,10 +138,10 @@ if ("${NETCDF_INCLUDE_DIRS}" STREQUAL "" OR "${NETCDF_LIBRARIES}" STREQUAL "")
     message(STATUS "Unable to infer the location of NetCDF!")
     message(STATUS "Either:")
     message(STATUS "1) Specify -DNETCDF_INCLUDE_DIRS:PATH=<dir>")
-    message(STATUS "           -DNETCDF_LIBRARIES=\"-L<dir> -lnetcdff -lnetcdf\"")
+    message(STATUS "           -DNETCDF_LIBRARIES=\"-L<dir> [-lnetcdff] -lnetcdf\"")
     message(STATUS "   (adding -lhdf5_hl -lhdf5 -ldl -lm -lz -lcurl and other libraries if needed)")
     message(STATUS "--or--")
-    message(STATUS "2) Make sure to have nc-config and nf-config in your PATH")
+    message(STATUS "2) Make sure to have nc-config [and optionally nf-config] in your PATH")
     message(STATUS "   so that NETCDF_INCLUDE_DIRS and NETCDF_LIBRARIES can be inferred")
     message(FATAL_ERROR "*******************************************************")
 endif()
@@ -140,6 +153,9 @@ include_directories(
 message(STATUS "NetCDF include dirs: ${NETCDF_INCLUDE_DIRS}")
 message(STATUS "NetCDF libraries: ${NETCDF_LIBRARIES}")
 
+#
+# Doxygen (optional)
+#
 find_package(Doxygen)
 if (DOXYGEN_FOUND)
     # set input and output files

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ for instance.
 If you want to call `MINT` from `Fortran`, `C` or `C++` we recommend that you build the `mint` library. In addition to the C++ and, optionally, the Fortran compilers you will need
 
  * CMake 
- * NetCDF with Fortran 77 bindings (libnetcdf and libnetcdff)
+ * C NetCDF and optionally Fortran NetCDF (libnetcdff)
  * VTK >= 8
 
 installed.
@@ -121,18 +121,21 @@ FC=pgfortran CXX=pgcxx cmake ..
 make -j 8
 ```
 
-The locations of the NetCDF library and headers are inferred from the `nc-config` and `nf-config` commands but these paths can be overriden. Likewise, the location of VTK can be specified manually.
-
+The locations of the NetCDF library and headers can be inferred from the `nc-config`. Use
+```
+cmake -D BUILD_FORTRAN=ON ..
+```
+to build the Fortran interface (requires libnetcdff to be installed). You can also specify the location of VTK and NetCDF manually.
 For instance, in the Anaconda prompt terminal on Windows 10 Entreprise:
 ```
 call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvars64.bat"
-cmake -G "NMake Makefiles" -DBUILD_FORTRAN=OFF -DVTK_INCLUDE_DIR="%userprofile%\miniconda3\envs\mint-dev\Library\include\vtk-9.0" -DVTK_LIBRARY_DIR="%userprofile%\miniconda3\envs\mint-dev\Library\lib" -DNETCDF_INCLUDE_DIRS="%userprofile%\miniconda3\envs\mint-dev\Library\include" -DNETCDF_LIBRARIES="%userprofile%\miniconda3\envs\mint-dev\Library\lib\netcdf.lib" ..
+cmake -G "NMake Makefiles" -DVTK_INCLUDE_DIR="%userprofile%\miniconda3\envs\mint-dev\Library\include\vtk-9.0" -DVTK_LIBRARY_DIR="%userprofile%\miniconda3\envs\mint-dev\Library\lib" -DNETCDF_INCLUDE_DIRS="%userprofile%\miniconda3\envs\mint-dev\Library\include" -DNETCDF_LIBRARIES="%userprofile%\miniconda3\envs\mint-dev\Library\lib\netcdf.lib" ..
 nmake
 ```
 
 You can check that the build was successful by typing:
 ```
-make test
+ctest
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The development of the numerical method and its implementation are supported by 
 
 ## References
 
-`MINT` implements the 2D+1D (horizontal plus a vertical axis) interpolation and regridding method described in 
+`MINT` implements the (2 + 1)D (horizontal plus a vertical axis) interpolation and regridding method described in 
 [Mimetic Interpolation of Vector Fields on Arakawa C/D Grids](https://journals.ametsoc.org/view/journals/mwre/147/1/mwr-d-18-0146.1.xml).
 
 This is a particular case of the more general family of methods described in [Conservative interpolation of edge and face data on n dimensional structured grids using differential forms](https://www.sciencedirect.com/science/article/pii/S0021999115005562?via%3Dihub).

--- a/requirements/mint.yml
+++ b/requirements/mint.yml
@@ -1,1 +1,1 @@
-py38.yml
+py39.yml

--- a/requirements/py37.yml
+++ b/requirements/py37.yml
@@ -4,19 +4,17 @@ channels:
   - conda-forge
 
 dependencies:
-  - python=3.7  # vtk for py39 is not available from PyPI @March 2021
+  - python=3.7
 
 # Setup dependencies.
   - cmake
   - cython
-  - doxygen
   - setuptools
   - tbb-devel
   - pip
 
 # Core dependencies.
   - libnetcdf
-  - netcdf-fortran
   - numpy
   - vtk=9.0.3
 

--- a/requirements/py38.yml
+++ b/requirements/py38.yml
@@ -4,19 +4,17 @@ channels:
   - conda-forge
 
 dependencies:
-  - python=3.9
+  - python=3.8
 
 # Setup dependencies.
   - cmake
   - cython
-  - doxygen
   - setuptools
   - tbb-devel
   - pip
 
 # Core dependencies.
   - libnetcdf
-  - netcdf-fortran
   - numpy
   - vtk=9.0.3
 

--- a/requirements/py39.yml
+++ b/requirements/py39.yml
@@ -9,14 +9,12 @@ dependencies:
 # Setup dependencies.
   - cmake
   - cython
-  - doxygen
   - setuptools
   - tbb-devel
   - pip
 
 # Core dependencies.
   - libnetcdf
-  - netcdf-fortran
   - numpy
   - vtk=9.0.3
 

--- a/src/MvVector.cpp
+++ b/src/MvVector.cpp
@@ -65,8 +65,7 @@ std::size_t Vector<T>::bra(T elem)
 {
   return static_cast<std::size_t>(
                  std::upper_bound(this->begin() + 1, 
-                          this->end(), 
-                          elem) - 
+                                  this->end(), elem) - 
                  this->begin() - 1);
 }
 
@@ -188,11 +187,10 @@ Vector<T> &Vector<T>::operator/=(const Vector<T> &w)
 
 
 template<class T>
-Vector<T> Vector<T>::operator()(const Vector<std::size_t> &I) const
+Vector<T> Vector<T>::operator()(const Vector<int> &I) const
 {
   Vector<T> y(I.size());
-
-  for (std::size_t i = I.size(); i--;)
+  for (std::size_t i = 0; i < I.size(); i++)
     y[i] = (*this)[ I[i] ];
   return y;
 }

--- a/src/MvVector.cpp
+++ b/src/MvVector.cpp
@@ -693,32 +693,6 @@ template Vector<double> operator/(const Vector<double>&, const Vector<double>&);
 template Vector<double> operator/(const Vector<double>&, double);
 template Vector<double> operator/(double, const Vector<double>&);
 
-// std::size_t
-template class Vector<std::size_t>;
-template Vector<std::size_t> range(std::size_t, std::size_t);
-template Vector<std::size_t> space(std::size_t, std::size_t, std::size_t);
-template std::size_t max(const Vector<std::size_t>&);
-template Vector<std::size_t> max(const Vector<std::size_t>&, std::size_t);
-template Vector<std::size_t> max(std::size_t, const Vector<std::size_t>&);
-template Vector<std::size_t> max(const Vector<std::size_t>&, const Vector<std::size_t>&);
-template std::size_t min(const Vector<std::size_t>&);
-template Vector<std::size_t> min(const Vector<std::size_t>&, std::size_t);
-template Vector<std::size_t> min(std::size_t, const Vector<std::size_t>&);
-template Vector<std::size_t> min(const Vector<std::size_t>&, const Vector<std::size_t>&);
-template std::size_t dot(const Vector<std::size_t>&, const Vector<std::size_t>&);
-template std::size_t sum(const Vector<std::size_t>&);
-template std::ostream& operator<<(std::ostream& s, const Vector<std::size_t>&);
-template Vector<std::size_t> cat(const Vector<std::size_t>&, const Vector<std::size_t>&);
-template Vector<std::size_t> operator+(const Vector<std::size_t>&, std::size_t);
-template Vector<std::size_t> operator+(std::size_t, const Vector<std::size_t>&);
-template Vector<std::size_t> operator+(const Vector<std::size_t>&, const Vector<std::size_t>&);
-template Vector<std::size_t> operator-(const Vector<std::size_t>&, std::size_t);
-template Vector<std::size_t> operator-(std::size_t, const Vector<std::size_t>&);
-template Vector<std::size_t> operator-(const Vector<std::size_t>&, const Vector<std::size_t>&);
-template Vector<std::size_t> operator-(const Vector<std::size_t>&);
-template Vector<std::size_t> operator*(const Vector<std::size_t>&, std::size_t);
-template Vector<std::size_t> operator*(std::size_t, const Vector<std::size_t>&);
-template Vector<std::size_t> operator*(const Vector<std::size_t>&, const Vector<std::size_t>&);
 
 // int
 template class Vector<int>;
@@ -746,7 +720,7 @@ template Vector<int> operator*(const Vector<int>&, int);
 template Vector<int> operator*(int, const Vector<int>&);
 template Vector<int> operator*(const Vector<int>&, const Vector<int>&);
 
-
+// complex
 template class Vector< std::complex<double> >;
 template Vector< std::complex<double> > space( std::complex<double> ,  std::complex<double> , std::size_t);
 template std::complex<double>  dot(const Vector< std::complex<double> >&, const Vector< std::complex<double> >&);

--- a/src/MvVector.h
+++ b/src/MvVector.h
@@ -213,7 +213,7 @@ public:
     return (*this)[i];
   }
 
-  Vector<T> operator()(const Vector<std::size_t> &I) const;
+  Vector<T> operator()(const Vector<int> &I) const;
 };
 
 typedef Vector<double> Vec;

--- a/src/mntNcFieldWrite.cpp
+++ b/src/mntNcFieldWrite.cpp
@@ -132,7 +132,7 @@ int mnt_ncfieldwrite_define(NcFieldWrite_t** self) {
     return 1;
   }  
 
-  std::size_t ndims = (*self)->dimSizes.size();
+  int ndims = (int) (*self)->dimSizes.size();
   std::vector<int> dimIds(ndims);
   int ier;
   for (std::size_t i = 0; i < ndims; ++i) {

--- a/src/mntRegridEdges.cpp
+++ b/src/mntRegridEdges.cpp
@@ -489,12 +489,12 @@ int mnt_regridedges_build(RegridEdges_t** self, int numCellsPerBucket, double pe
     std::string msg;
     // checks
     if (!(*self)->srcGrid) {
-        msg + "must set source grid";
+        msg = "must set source grid";
         mntlog::error(__FILE__, __func__, __LINE__, msg);
         return 1;
     }
     if (!(*self)->dstGrid) {
-        msg + "must set destination grid\n";
+        msg = "must set destination grid\n";
         mntlog::error(__FILE__, __func__, __LINE__, msg);
         return 2;
     }
@@ -1109,4 +1109,3 @@ int mnt_regridedges_print(RegridEdges_t** self) {
     }
     return 0;
 }
-

--- a/tests/testCmdLineArgParserC.cxx
+++ b/tests/testCmdLineArgParserC.cxx
@@ -1,7 +1,8 @@
-#include <mntCmdLineArgParser.h>
-#include <cassert>
 #include <cstring>
+#include <cassert>
 #include <iostream>
+
+#include <mntCmdLineArgParser.h>
 
 int main(int argc, char** argv) {
 

--- a/tests/testSimpleRegridEdges.cpp
+++ b/tests/testSimpleRegridEdges.cpp
@@ -39,7 +39,7 @@ int main() {
     assert(ier == 0);
     
     std::string outputFilename = "simpleRegridEdgesWeights.nc";
-    ier = mnt_regridedges_dumpWeights(&rg, outputFilename.c_str(), outputFilename.size());
+    ier = mnt_regridedges_dumpWeights(&rg, outputFilename.c_str(), (int) outputFilename.size());
     assert(ier == 0);
 
     // edges point in the positive direction


### PR DESCRIPTION
From now on, fortran interfaces are compiled only when requested. This reduces the number of external dependencies and makes it easier to build on Windows and Mac OS X, which may not come with a Fortran compiler. 